### PR TITLE
Ensure setup-e2e-tests.ps1 requires PowerShell 6+

### DIFF
--- a/setup-e2e-tests.ps1
+++ b/setup-e2e-tests.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 6
+
 param(
     [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
Running the script as is in a PS5 console on Windows blindly downloads the linux build. Which is... unexpected ;-)

Indeed, `$IsWindows` and friends are only available in PS6+.

The proposed change requires PS6 as a minimum to be upfront with expectations rather than having the caller try and troubleshoot the problem by himself/herself.
